### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/_workflows/main.yml
+++ b/.github/_workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: docker.pkg.github.com
           name: docker.pkg.github.com/IldarExpert/nextjs-rating/nextjs-rating


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore